### PR TITLE
[#1] normalize lclsfNm(main_category), mclsfNm(sub_category) in policy_category

### DIFF
--- a/policy.dbml
+++ b/policy.dbml
@@ -26,10 +26,20 @@ Table policy {
   last_modified_at      timestamp [note: 'lastMdfcnDt - 최종수정일시']
 }
 
+Table category_group {
+  id    int [pk, increment]
+  name  varchar [note: 'lclsfNm - 정책대분류']
+}
+
+Table category {
+  id       int [pk, increment]
+  group_id int [ref: > category_group.id]
+  name     varchar [note: 'mclsfNm - 정책중분류']
+}
+
 Table policy_category {
-  policy_id       varchar [ref: > policy.policy_id]
-  main_category   varchar [note: 'lclsfNm - 정책대분류']
-  sub_category    varchar [note: 'mclsfNm - 정책중분류']
+  policy_id   varchar [ref: > policy.policy_id]
+  category_id int     [ref: > category.id]
 }
 
 Table policy_condition {


### PR DESCRIPTION
# 관련 이슈
- #1 

# 수정 사항
- 기존 policy_category의 main_category, sub_category 필드를 정규화

# 참고 사항
category_group (대분류) | category (중분류)
-- | --
일자리 | 취업, 재직자, 창업
주거 | 주택 및 거주지, 기숙사, 전월세 및 주거급여 지원
교육 | 미래역량강화, 교육비지원, 온라인교육
복지문화 | 취약계층 및 금융지원, 건강, 예술인지원, 문화활동
참여권리 | 청년참여, 정책인프라구축, 청년국제교류, 권익보호