### PR TITLE
[#7] 온통청년 API에서 제공하는 필드 누락

### DIFF
--- a/policy.dbml
+++ b/policy.dbml
@@ -80,6 +80,8 @@ Table policy_meta {
   approval_status_cd   varchar [ref: > code.id, note: 'plcyAprvSttsCd - 승인상태코드']
   policy_method_cd     varchar [ref: > code.id, note: 'plcyPvsnMthdCd - 제공방법코드']
   provider_group_cd    varchar [ref: > code.id, note: 'pvsnInstGroupCd - 제공기관그룹코드']
+  application_period_cd varchar [ref: > code.id, note: 'aplyPrdSeCd - 신청기간구분코드']
+  business_period_cd    varchar [ref: > code.id, note: 'bizPrdSeCd - 사업기간구분코드']
 }
 
 Table organization {


### PR DESCRIPTION
# 관련 이슈
- #7 

# 내용
- 아래 온통청년 API에서 제공되는 필드 누락에 따른 추가 (policy_meta table)
  - `aplyPrdSeCd` (신청기간구분코드) -> `application_period_cd` (실제 컬럼명)
  - `bizPrdSeCd ` (사업기간구분코드) -> `business_period_cd` (실제 컬럼명)

